### PR TITLE
Fixed: sidebar route-name using snake_word table

### DIFF
--- a/packages/thunderclap/stubs/laravolt/Providers/ServiceProvider.php.stub
+++ b/packages/thunderclap/stubs/laravolt/Providers/ServiceProvider.php.stub
@@ -25,7 +25,7 @@ class :ModuleName:ServiceProvider extends BaseServiceProvider
     {
         app('laravolt.menu.sidebar')->register(function ($menu) {
             $menu->modules
-                ->add(':Module Name:', route('modules:::moduleName:.index'))
+                ->add(':Module Name:', route('modules:::module-name:.index'))
                 ->data('icon', 'circle outline')
                 ->data('permission', $this->config['permission'] ?? [])
                 ->active('modules/:module-name:/*');


### PR DESCRIPTION
Using the right way of route-naming for sidebar menu from snake_case from table name.

this stub :
![image](https://user-images.githubusercontent.com/52684582/104104407-8dc86200-52da-11eb-8675-66c883dbf8c3.png)

generating this provider :
![image](https://user-images.githubusercontent.com/52684582/104104434-bb151000-52da-11eb-80fc-0d16334347a5.png)

throw this error :
![image](https://user-images.githubusercontent.com/52684582/104104347-ffec7700-52d9-11eb-82b1-71256d3532ba.png)

because the routes using kebab-case..