### PR TITLE
Fixed: Module Name for naming sidebar

### DIFF
--- a/packages/thunderclap/src/Commands/Generator.php
+++ b/packages/thunderclap/src/Commands/Generator.php
@@ -100,7 +100,7 @@ class Generator extends Command
             ':module_name:' => snake_case(Str::singular($table)),
             ':module-name:' => $templates['module-name'],
             ':module name:' => str_replace('_', ' ', strtolower(Str::singular($table))),
-            ':Module Name:' => $moduleName,
+            ':Module Name:' => Str::singular(str_replace('_', ' ', Str::title($table))),
             ':moduleName:' => lcfirst($moduleName),
             ':ModuleName:' => $moduleName,
             ':SEARCHABLE_COLUMNS:' => $this->transformer->toSearchableColumns(),


### PR DESCRIPTION
generate the right title for Module Name used in sidebar menu.

this generator :
![image](https://user-images.githubusercontent.com/52684582/104104685-34f9c900-52dc-11eb-8074-c3ff44a5b43e.png)

![image](https://user-images.githubusercontent.com/52684582/104104635-f401b480-52db-11eb-89e5-b6b4bc927b90.png)

used in modules/../ServiceProviders.php.stub :
![image](https://user-images.githubusercontent.com/52684582/104104674-1f849f00-52dc-11eb-9508-6dea55f369f0.png)

return this menu :
![image](https://user-images.githubusercontent.com/52684582/104104711-55c21e80-52dc-11eb-8377-9c392b65550c.png)
![image](https://user-images.githubusercontent.com/52684582/104104731-78ecce00-52dc-11eb-86d8-2ecedb96e161.png)
